### PR TITLE
use abspath for compatibility with Windows

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -158,8 +158,8 @@ def do_cli(function_identifier,  # pylint: disable=too-many-locals
 
             click.secho("\nBuild Succeeded", fg="green")
 
-            msg = gen_success_msg(os.path.relpath(ctx.build_dir),
-                                  os.path.relpath(ctx.output_template_path),
+            msg = gen_success_msg(os.path.abspath(ctx.build_dir),
+                                  os.path.abspath(ctx.output_template_path),
                                   os.path.abspath(ctx.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR))
 
             click.secho(msg, fg="yellow")


### PR DESCRIPTION
relpath fails when the specified path is on another drive in Windows

*Issue #, if available:* #1336

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
